### PR TITLE
Image names will be prefixed by their order in the album

### DIFF
--- a/imgurdownloader/__init__.py
+++ b/imgurdownloader/__init__.py
@@ -124,10 +124,10 @@ def save_image(info, destination, num = ''):
     sluger = UniqueSlugify(uids=os.listdir(destination))
     slug = sluger(title)
     filename = ""
-    if num == '':
-        filename = "%s.%s" % (slug, suffix)
-    else:
+    if G['ordered']:
         filename = "%s - %s.%s" % (num, slug, suffix)
+    else:
+        filename = "%s.%s" % (slug, suffix)
     filepath = os.path.join(destination, filename)
 
     download(info['link'], filepath)
@@ -136,10 +136,10 @@ def save_image(info, destination, num = ''):
 
     if description:
         txtpath = ''
-        if num == '':
-            txtpath = os.path.join(destination, '%s.txt' % slug)
-        else:
+        if G['ordered']:
             txtpath = os.path.join(destination, '%s - %s.txt' % (num, slug))
+        else:
+            txtpath = os.path.join(destination, '%s.txt' % slug)
 
         with open(txtpath, 'w') as f:
             f.write("Title: %s\r" % title)

--- a/imgurdownloader/__init__.py
+++ b/imgurdownloader/__init__.py
@@ -126,10 +126,8 @@ def save_image(info, destination, num = ''):
     filename = ""
     if num == '':
         filename = "%s.%s" % (slug, suffix)
-        logger.info("Image order not given")
     else:
         filename = "%s - %s.%s" % (num, slug, suffix)
-        logger.info("Image order is {}".format(num))
     filepath = os.path.join(destination, filename)
 
     download(info['link'], filepath)
@@ -254,7 +252,10 @@ def download_album(url=None, album=None, destination=None):
     count = 1
     for info in res['data']:
         strcount = str(count)
-        save_image(info, album_path, strcount.zfill(image_count_len))
+        if G['ordered']:
+            save_image(info, album_path, strcount.zfill(image_count_len))
+        else:
+            save_image(info, album_path)
         count += 1
 
 
@@ -270,9 +271,11 @@ def request(url):
               default=False,
               help="Discover other albums in image descriptions")
 @click.option('-v', '--verbose', count=True, help="Verbose mode")
+@click.option('--ordered/--not-ordered', default=False,
+              help="Whether the images' names will be prefixed by their order in the album")
 @click.argument("url")
 @click.argument("destination")
-def downloader(url, destination, recursive, verbose):
+def downloader(url, destination, recursive, verbose, ordered):
     settings = get_settings()
     clientid = settings['clientid']
 
@@ -284,6 +287,7 @@ def downloader(url, destination, recursive, verbose):
     G['clientid'] = clientid
     G['base'] = destination
     G['find-albums'] = recursive
+    G['ordered'] = ordered
 
     processor.put(lambda: download_album(url=url))
     processor.start()

--- a/imgurdownloader/__init__.py
+++ b/imgurdownloader/__init__.py
@@ -100,11 +100,12 @@ def download(link, destination):
             f.write(chunk)
 
 
-def save_image(info, destination):
+def save_image(info, destination, num = ''):
     """ Downloads the image to the URL
 
     @param info: dict with metadata about image
     @param destination: directory where to download
+    @param num: image's (numeric) order in the album
     """
 
     url = info['link']
@@ -122,7 +123,13 @@ def save_image(info, destination):
 
     sluger = UniqueSlugify(uids=os.listdir(destination))
     slug = sluger(title)
-    filename = "%s.%s" % (slug, suffix)
+    filename = ""
+    if num == '':
+        filename = "%s.%s" % (slug, suffix)
+        logger.info("Image order not given")
+    else:
+        filename = "%s - %s.%s" % (num, slug, suffix)
+        logger.info("Image order is {}".format(num))
     filepath = os.path.join(destination, filename)
 
     download(info['link'], filepath)
@@ -130,7 +137,12 @@ def save_image(info, destination):
     description = info['description']
 
     if description:
-        txtpath = os.path.join(destination, '%s.txt' % slug)
+        txtpath = ''
+        if num == '':
+            txtpath = os.path.join(destination, '%s.txt' % slug)
+        else:
+            txtpath = os.path.join(destination, '%s - %s.txt' % (num, slug))
+
         with open(txtpath, 'w') as f:
             f.write("Title: %s\r" % title)
             f.write("Description: %s\r" % description)
@@ -236,8 +248,14 @@ def download_album(url=None, album=None, destination=None):
     if res['status'] != 200 or not(res['success']):
         return False
 
+    image_count = meta['images_count']
+    image_count_len = len(str(image_count))
+
+    count = 1
     for info in res['data']:
-        save_image(info, album_path)
+        strcount = str(count)
+        save_image(info, album_path, strcount.zfill(image_count_len))
+        count += 1
 
 
 def request(url):


### PR DESCRIPTION
Hi,
I added code, that will prepend the image's order in the album to their names. This can be toggled on the command line by --ordered/--not-ordered, with the unordered option being the default.

I wish you nice holidays.